### PR TITLE
resurtm.kz → resurtm.com

### DIFF
--- a/form.file.upload.fat.model.txt
+++ b/form.file.upload.fat.model.txt
@@ -303,7 +303,7 @@ class Item extends CActiveRecord{
 ситуацию, когда две разные модели могут иметь два файла с одним и тем-же именем.
 
 ---
-  - `Автор`: [resurtm](http://resurtm.kz/)
+  - `Автор`: [resurtm](http://resurtm.com/)
   - `Дополнения`: [mc-bear](http://yiiframework.ru/forum/memberlist.php?mode=viewprofile&u=58)
   - `Оригинальный рецепт`: [как загрузить файл используя модель](form.file.upload)
   - `Английский рецепт`: [how to upload a file using a model](http://www.yiiframework.com/wiki/2/)

--- a/model.data.provider.iterator.txt
+++ b/model.data.provider.iterator.txt
@@ -152,5 +152,5 @@ class UserCommand extends CConsoleCommand{
   [mutex](http://www.yiiframework.com/extension/mutex).
 
 ---
-  - `Автор`: [resurtm](http://resurtm.kz/)
+  - `Автор`: [resurtm](http://resurtm.com/)
   - `Обсуждение и комментарии`: [тема на форуме](http://yiiframework.ru/forum/viewtopic.php?f=8&t=9854&p=57285)


### PR DESCRIPTION
Домен resurtm.kz я потерял, поэтому лучше сменить ссылку на новый домен, чтобы не помогать раскручивать левый сайт тех, кто собственно домен и перехватил. :-)
